### PR TITLE
fix: update component file paths

### DIFF
--- a/packages/plugins/src/nuxt/index.ts
+++ b/packages/plugins/src/nuxt/index.ts
@@ -50,7 +50,7 @@ export default defineNuxtModule<ModuleOptions>({
       addComponent({
         name: `${options.prefix}${component}`,
         export: component,
-        filePath: '@oku-ui/primitives',
+        filePath: '@oku-ui/motion',
       })
     }
 

--- a/packages/plugins/src/resolver/index.ts
+++ b/packages/plugins/src/resolver/index.ts
@@ -21,7 +21,7 @@ export default function (options: ResolverOptions = {}): ComponentResolver {
         if (Object.values(components).flat().includes(componentName)) {
           return {
             name: componentName,
-            from: '@oku-ui/primitives',
+            from: '@oku-ui/motion',
           }
         }
       }


### PR DESCRIPTION
close #68 

This pull request includes changes to update the file paths for components from `@oku-ui/primitives` to `@oku-ui/motion`. These changes are made to ensure that the components are correctly imported from the new package.

File path updates:

* [`packages/plugins/src/nuxt/index.ts`](diffhunk://#diff-407fe292ec4e6371f33fdf2e5a9cd0147644264861afd8145a9d32d185f5dc1fL53-R53): Updated the `filePath` for components to `@oku-ui/motion` in the `defineNuxtModule` function.
* [`packages/plugins/src/resolver/index.ts`](diffhunk://#diff-4e6243973f2cffaf41f36112660429bb9c2de4668f5cef289e653d44219f8ee6L24-R24): Updated the `from` field for components to `@oku-ui/motion` in the `ComponentResolver` function.