### PR TITLE
fix: build and preview

### DIFF
--- a/.docs/package.json
+++ b/.docs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@oku-ui/motion": "workspace:^",
-    "@oku-ui/primitives": "^0.7.3",
+    "@oku-ui/primitives": "^0.7.5",
     "@shikijs/vitepress-twoslash": "^1.23.1",
     "@stackblitz/sdk": "^1.11.0",
     "@vueuse/core": "^11.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -90,7 +90,7 @@
     "@vue/shared": "^3.4.31"
   },
   "dependencies": {
-    "@oku-ui/primitives": "^0.7.3",
+    "@oku-ui/primitives": "^0.7.5",
     "defu": "^6.1.4",
     "framer-motion": "^11.11.17",
     "hey-listen": "^1.0.8",

--- a/packages/core/src/composables/usePrimitiveElement.ts
+++ b/packages/core/src/composables/usePrimitiveElement.ts
@@ -1,17 +1,7 @@
 import { computed, ref } from 'vue'
 import type { ComponentPublicInstance } from 'vue'
 
-// TODO: error handling
-// import { getElFromTemplateRef } from '@oku-ui/primitives/shared'
-
-export function getElFromTemplateRef<T extends HTMLElement>(nodeRef: any) {
-  let node: T | undefined = (nodeRef as ComponentPublicInstance)?.$el ?? nodeRef
-
-  if (node && node.nodeType !== 1)
-    node = undefined
-
-  return node
-}
+import { getElFromTemplateRef } from '@oku-ui/primitives'
 
 export function usePrimitiveElement() {
   const primitiveElement = ref<ComponentPublicInstance>()

--- a/packages/core/src/share/context.ts
+++ b/packages/core/src/share/context.ts
@@ -1,4 +1,4 @@
-import { createContext } from '@oku-ui/primitives/hooks'
+import { createContext } from '@oku-ui/primitives'
 import type { Ref } from 'vue'
 import { ref } from 'vue'
 import type { MotionState } from '@/state/motion-state'

--- a/packages/plugins/src/nuxt/index.ts
+++ b/packages/plugins/src/nuxt/index.ts
@@ -10,7 +10,7 @@ export interface ModuleOptions {
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: '@oku-ui/motion',
-    configKey: 'motion',
+    configKey: 'okuMotion',
     compatibility: {
       nuxt: '>=3.14',
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,8 +123,8 @@ importers:
         specifier: workspace:^
         version: link:../packages/core
       '@oku-ui/primitives':
-        specifier: ^0.7.3
-        version: 0.7.3(@vue/shared@3.5.13)(vue@3.5.13(typescript@5.6.3))
+        specifier: ^0.7.5
+        version: 0.7.5(vue@3.5.13(typescript@5.6.3))
       '@shikijs/vitepress-twoslash':
         specifier: ^1.23.1
         version: 1.23.1(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.3))(typescript@5.6.3)
@@ -199,8 +199,8 @@ importers:
   packages/core:
     dependencies:
       '@oku-ui/primitives':
-        specifier: ^0.7.3
-        version: 0.7.3(@vue/shared@3.5.13)(vue@3.5.13(typescript@5.6.3))
+        specifier: ^0.7.5
+        version: 0.7.5(vue@3.5.13(typescript@5.6.3))
       '@vue/shared':
         specifier: ^3.4.31
         version: 3.5.13
@@ -1412,10 +1412,10 @@ packages:
     peerDependencies:
       vue: ^3.3.4
 
-  '@oku-ui/primitives@0.7.3':
-    resolution: {integrity: sha512-KF1I1sHql05G38ZKjAgxUH7FNdeMySSGLAtJgLu2MXNDjLUVZYZOfL0lP8dvMOhWeBwA6Jy2uUBmo6HkappIzA==}
+  '@oku-ui/primitives@0.7.5':
+    resolution: {integrity: sha512-VE92PAc3L7JfKgLqNgFzzBVT1o5oghdqPXUFsle0sEPg434B59hcHaOj6fskgDSmy49OPl3TrMCh/VgjYmOQXA==}
     peerDependencies:
-      '@vue/shared': ^3.4.31
+      vue: '>= 3.5.0'
 
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
@@ -9281,16 +9281,15 @@ snapshots:
       - vti
       - vue-tsc
 
-  '@oku-ui/primitives@0.7.3(@vue/shared@3.5.13)(vue@3.5.13(typescript@5.6.3))':
+  '@oku-ui/primitives@0.7.5(vue@3.5.13(typescript@5.6.3))':
     dependencies:
       '@floating-ui/dom': 1.6.12
       '@floating-ui/utils': 0.2.8
       '@floating-ui/vue': 1.1.5(vue@3.5.13(typescript@5.6.3))
-      '@vue/shared': 3.5.13
       aria-hidden: 1.2.4
+      vue: 3.5.13(typescript@5.6.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
-      - vue
 
   '@one-ini/wasm@0.1.1': {}
 


### PR DESCRIPTION
close #68 

This pull request includes several updates to dependencies and refactoring of imports across multiple files. The most important changes are the version update of the `@oku-ui/primitives` package and the refactoring of imports to use the updated package.

Dependency updates:

* Updated the version of `@oku-ui/primitives` from `^0.7.3` to `^0.7.5` in `.docs/package.json` and `packages/core/package.json`. [[1]](diffhunk://#diff-318c2366fe549ec019d3c962986995668dc122f5bbb5a6f5b1a72bb11f1e5e00L17-R17) [[2]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L93-R93)

Refactoring imports:

* Refactored `usePrimitiveElement.ts` to import `getElFromTemplateRef` from `@oku-ui/primitives` instead of defining it locally.
* Refactored `context.ts` to import `createContext` from `@oku-ui/primitives` instead of `@oku-ui/primitives/hooks`.

Lock file updates:

* Updated `pnpm-lock.yaml` to reflect the new version of `@oku-ui/primitives` and its dependencies. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL126-R127) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL202-R203) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1415-R1418) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9284-L9293)